### PR TITLE
Update the ccache folders to 4.0+

### DIFF
--- a/cip/Jenkinsfile
+++ b/cip/Jenkinsfile
@@ -74,7 +74,7 @@ node('docker') {
       def job = env.JOB_BASE_NAME.toLowerCase().replace('%2f', '_')
       def container = "ci-$job-$BUILD_NUMBER".toLowerCase()
       docker.image("$image").inside("-u ciuser:docker \
-                                     -v $HOME/.ccache:/home/ciuser/.ccache \
+                                     -v $HOME/.config/ccache:/home/ciuser/.config/ccache \
                                      -v $HOME/.cache:/home/ciuser/.cache \
                                      -v /var/run/docker.sock:/var/run/docker.sock \
                                      -v /usr/bin/docker:/usr/bin/docker \


### PR DESCRIPTION
Version 4.0+ now uses XDG standard location by default, ~/.config/ccache and ~/.cache/ccache